### PR TITLE
Specify the version of openai to be 0.27

### DIFF
--- a/chapter9/9-3-quiz-chatgpt.ipynb
+++ b/chapter9/9-3-quiz-chatgpt.ipynb
@@ -73,7 +73,7 @@
     }
    ],
    "source": [
-    "!pip install datasets openai tiktoken tqdm"
+    "!pip install datasets openai==0.27 tiktoken tqdm"
    ]
   },
   {

--- a/chapter9/9-5-quiz-chatgpt-plus-bpr.ipynb
+++ b/chapter9/9-5-quiz-chatgpt-plus-bpr.ipynb
@@ -165,7 +165,7 @@
     }
    ],
    "source": [
-    "!pip install datasets openai tiktoken transformers[ja] faiss-cpu"
+    "!pip install datasets openai==0.27 tiktoken transformers[ja] faiss-cpu"
    ]
   },
   {


### PR DESCRIPTION
OpenAI のライブラリがメジャーアップデートされ、仕様が変わってしまった。
ノートブックをそのまま実行できるように、`pip install openai==0.27` とバージョンを固定するように変更。
https://github.com/ghmagazine/llm-book/issues/26