### PR TITLE
Fix dataset loading error in 10-2a notebook

### DIFF
--- a/chapter10/10-2a-llm-jp-eval-dataset.ipynb
+++ b/chapter10/10-2a-llm-jp-eval-dataset.ipynb
@@ -118,7 +118,7 @@
         }
       ],
       "source": [
-        "!pip install datasets rhoknp xmltodict"
+        "!pip install datasets rhoknp xmltodict fsspec==2023.9.2"
       ]
     },
     {


### PR DESCRIPTION
The notebook raised a NotImplementedError when loading a dataset on Google Colab,
possibly due to incompatibility between the datasets library and recent fsspec versions.
This fix pins fsspec to version 2023.9.2, which has been confirmed to work with the datasets library on the current Colab environment.
