### PR TITLE
`datasets` のバージョンを 3.6.0 に固定

### DIFF
--- a/chapter05/5-2-sentiment-analysis-finetuning-wrime.ipynb
+++ b/chapter05/5-2-sentiment-analysis-finetuning-wrime.ipynb
@@ -186,7 +186,7 @@
         }
       ],
       "source": [
-        "!pip install transformers[ja,torch] datasets matplotlib japanize-matplotlib"
+        "!pip install transformers[ja,torch] datasets==3.6.0 matplotlib japanize-matplotlib"
       ]
     },
     {

--- a/chapter05/5-2-sentiment-analysis-finetuning.ipynb
+++ b/chapter05/5-2-sentiment-analysis-finetuning.ipynb
@@ -196,7 +196,7 @@
         }
       ],
       "source": [
-        "!pip install transformers[ja,torch] datasets matplotlib japanize-matplotlib"
+        "!pip install transformers[ja,torch] datasets==3.6.0 matplotlib japanize-matplotlib"
       ]
     },
     {

--- a/chapter05/5-3-sentiment-analysis-analysis-wrime.ipynb
+++ b/chapter05/5-3-sentiment-analysis-analysis-wrime.ipynb
@@ -173,7 +173,7 @@
         }
       ],
       "source": [
-        "!pip install datasets transformers[ja,torch] matplotlib scikit-learn"
+        "!pip install datasets==3.6.0 transformers[ja,torch] matplotlib scikit-learn"
       ]
     },
     {

--- a/chapter05/5-3-sentiment-analysis-analysis.ipynb
+++ b/chapter05/5-3-sentiment-analysis-analysis.ipynb
@@ -183,7 +183,7 @@
         }
       ],
       "source": [
-        "!pip install datasets transformers[ja,torch] matplotlib scikit-learn"
+        "!pip install datasets==3.6.0 transformers[ja,torch] matplotlib scikit-learn"
       ]
     },
     {

--- a/chapter05/5-4-multiple-choice-qa-analysis.ipynb
+++ b/chapter05/5-4-multiple-choice-qa-analysis.ipynb
@@ -180,7 +180,7 @@
         }
       ],
       "source": [
-        "!pip install datasets transformers[ja,torch] matplotlib scikit-learn"
+        "!pip install datasets==3.6.0 transformers[ja,torch] matplotlib scikit-learn"
       ]
     },
     {

--- a/chapter05/5-4-multiple-choice-qa-finetuning.ipynb
+++ b/chapter05/5-4-multiple-choice-qa-finetuning.ipynb
@@ -193,7 +193,7 @@
         }
       ],
       "source": [
-        "!pip install transformers[ja,torch] datasets matplotlib japanize-matplotlib"
+        "!pip install transformers[ja,torch] datasets==3.6.0 matplotlib japanize-matplotlib"
       ]
     },
     {

--- a/chapter05/5-4-nli-analysis.ipynb
+++ b/chapter05/5-4-nli-analysis.ipynb
@@ -180,7 +180,7 @@
         }
       ],
       "source": [
-        "!pip install datasets transformers[ja,torch] matplotlib scikit-learn"
+        "!pip install datasets==3.6.0 transformers[ja,torch] matplotlib scikit-learn"
       ]
     },
     {

--- a/chapter05/5-4-nli-finetuning.ipynb
+++ b/chapter05/5-4-nli-finetuning.ipynb
@@ -193,7 +193,7 @@
         }
       ],
       "source": [
-        "!pip install transformers[ja,torch] datasets matplotlib japanize-matplotlib"
+        "!pip install transformers[ja,torch] datasets==3.6.0 matplotlib japanize-matplotlib"
       ]
     },
     {

--- a/chapter05/5-4-sts-analysis.ipynb
+++ b/chapter05/5-4-sts-analysis.ipynb
@@ -183,7 +183,7 @@
         }
       ],
       "source": [
-        "!pip install datasets transformers[ja,torch] matplotlib japanize-matplotlib"
+        "!pip install datasets==3.6.0 transformers[ja,torch] matplotlib japanize-matplotlib"
       ]
     },
     {

--- a/chapter05/5-4-sts-finetuning.ipynb
+++ b/chapter05/5-4-sts-finetuning.ipynb
@@ -193,7 +193,7 @@
         }
       ],
       "source": [
-        "!pip install transformers[ja,torch] datasets matplotlib japanize-matplotlib"
+        "!pip install transformers[ja,torch] datasets==3.6.0 matplotlib japanize-matplotlib"
       ]
     },
     {

--- a/chapter05/5-5-sentiment-analysis-finetuning-LoRA-wrime.ipynb
+++ b/chapter05/5-5-sentiment-analysis-finetuning-LoRA-wrime.ipynb
@@ -199,7 +199,7 @@
         }
       ],
       "source": [
-        "!pip install transformers[ja,torch] datasets matplotlib japanize-matplotlib peft"
+        "!pip install transformers[ja,torch] datasets==3.6.0 matplotlib japanize-matplotlib peft"
       ]
     },
     {

--- a/chapter05/5-5-sentiment-analysis-finetuning-LoRA.ipynb
+++ b/chapter05/5-5-sentiment-analysis-finetuning-LoRA.ipynb
@@ -199,7 +199,7 @@
         }
       ],
       "source": [
-        "!pip install transformers[ja,torch] datasets matplotlib japanize-matplotlib peft"
+        "!pip install transformers[ja,torch] datasets==3.6.0 matplotlib japanize-matplotlib peft"
       ]
     },
     {

--- a/chapter06/6-named-entity-recognition.ipynb
+++ b/chapter06/6-named-entity-recognition.ipynb
@@ -169,7 +169,7 @@
         }
       ],
       "source": [
-        "!pip install datasets transformers[ja,torch] spacy-alignments seqeval"
+        "!pip install datasets==3.6.0 transformers[ja,torch] spacy-alignments seqeval"
       ]
     },
     {

--- a/chapter07/7-summarization-generation.ipynb
+++ b/chapter07/7-summarization-generation.ipynb
@@ -173,7 +173,7 @@
         }
       ],
       "source": [
-        "!pip install datasets transformers[ja,torch] sentencepiece japanize-matplotlib"
+        "!pip install datasets==3.6.0 transformers[ja,torch] sentencepiece japanize-matplotlib"
       ]
     },
     {

--- a/chapter08/8-3-simcse-training.ipynb
+++ b/chapter08/8-3-simcse-training.ipynb
@@ -8738,7 +8738,7 @@
       ],
       "source": [
         "# 必要なパッケージをインストールする\n",
-        "!pip install datasets scipy transformers[ja,torch]"
+        "!pip install datasets==3.6.0 scipy transformers[ja,torch]"
       ]
     },
     {

--- a/chapter08/8-4-simcse-faiss.ipynb
+++ b/chapter08/8-4-simcse-faiss.ipynb
@@ -4506,7 +4506,7 @@
     {
       "cell_type": "code",
       "source": [
-        "!pip install datasets faiss-cpu scipy transformers[ja,torch]"
+        "!pip install datasets==3.6.0 faiss-cpu scipy transformers[ja,torch]"
       ],
       "metadata": {
         "colab": {

--- a/chapter09/9-3-quiz-chatgpt.ipynb
+++ b/chapter09/9-3-quiz-chatgpt.ipynb
@@ -73,7 +73,7 @@
         }
       ],
       "source": [
-        "!pip install datasets openai==0.27 tiktoken tqdm"
+        "!pip install datasets==3.6.0 openai==0.27 tiktoken tqdm"
       ]
     },
     {

--- a/chapter09/9-4-3-bpr-training.ipynb
+++ b/chapter09/9-4-3-bpr-training.ipynb
@@ -165,7 +165,7 @@
         }
       ],
       "source": [
-        "!pip install datasets torch transformers[ja,torch]"
+        "!pip install datasets==3.6.0 torch transformers[ja,torch]"
       ]
     },
     {

--- a/chapter09/9-4-4-bpr-embedding.ipynb
+++ b/chapter09/9-4-4-bpr-embedding.ipynb
@@ -2112,7 +2112,7 @@
     {
       "cell_type": "code",
       "source": [
-        "!pip install datasets faiss-cpu torch transformers[ja,torch]"
+        "!pip install datasets==3.6.0 faiss-cpu torch transformers[ja,torch]"
       ],
       "metadata": {
         "colab": {

--- a/chapter09/9-5-quiz-chatgpt-plus-bpr.ipynb
+++ b/chapter09/9-5-quiz-chatgpt-plus-bpr.ipynb
@@ -165,7 +165,7 @@
         }
       ],
       "source": [
-        "!pip install datasets openai==0.27 tiktoken transformers[ja] faiss-cpu"
+        "!pip install datasets==3.6.0 openai==0.27 tiktoken transformers[ja] faiss-cpu"
       ]
     },
     {

--- a/chapter10/10-2c-llm-jp-eval-jcommonsenseqa.ipynb
+++ b/chapter10/10-2c-llm-jp-eval-jcommonsenseqa.ipynb
@@ -184,7 +184,7 @@
         }
       ],
       "source": [
-        "!pip install transformers[torch,sentencepiece] bitsandbytes datasets"
+        "!pip install transformers[torch,sentencepiece] bitsandbytes datasets==3.6.0"
       ]
     },
     {

--- a/chapter10/10-3a-ja-vicuna-qa.ipynb
+++ b/chapter10/10-3a-ja-vicuna-qa.ipynb
@@ -337,7 +337,7 @@
         }
       ],
       "source": [
-        "!pip install bitsandbytes datasets transformers[torch,sentencepiece] openai"
+        "!pip install bitsandbytes datasets==3.6.0 transformers[torch,sentencepiece] openai"
       ]
     },
     {

--- a/chapter13/13-3-1-rag-instruct.ipynb
+++ b/chapter13/13-3-1-rag-instruct.ipynb
@@ -11446,7 +11446,7 @@
         }
       ],
       "source": [
-        "!pip install datasets transformers[torch,sentencepiece] trl peft bitsandbytes"
+        "!pip install datasets==3.6.0 transformers[torch,sentencepiece] trl peft bitsandbytes"
       ]
     },
     {


### PR DESCRIPTION
- https://github.com/ghmagazine/llm-book/issues/55 を解決します

`datasets` ライブラリが 4.0.0 にアップデートされた際に、リポジトリ内の Python スクリプトを実行してデータを読み込む機能が廃止されました。

[4.0.0 のリリースノート](https://github.com/huggingface/datasets/releases/tag/4.0.0) より
> Remove scripts altogether by @lhoestq in https://github.com/huggingface/datasets/pull/7592
> trust_remote_code is no longer supported

大規模言語モデル入門の Hugging Face リポジトリで公開しているデータセットの多くは、スクリプトを使用して、データセットを公開元からダウンロードして読み込む形をとっています。
`datasets` ライブラリでデータセットを引き続き読み込めるようにするために、バージョンを 4.0.0 直前の最新である 3.6.0 に固定します。

## そ検討事項

- 第11章（指示チューニング）および第12章（選好チューニング）で使用しているデータセットは、データセットそのものを Hugging Face リポジトリにアップロードしています。この形式では 4.0.0 以降も読み込めるため、ノートブックの更新は本 PR で行っていません。

- ノートブックから参照している Hugging Face リポジトリに、読み込みスクリプトではなく、データセットそのものをアップロードすれば、バージョン 4.0.0 以降でも読み込めるようになります。ただし、スクリプト方式には、データセットの再配布に際して発生するライセンス上の配慮を考えずに済むようにしたい、というねらいがあり、ひとまず現行の形でいきたいと思います。
