### PR TITLE
`transformers` のバージョンを `4.41.0` 未満に固定

### DIFF
--- a/chapter05/5-2-sentiment-analysis-finetuning-wrime.ipynb
+++ b/chapter05/5-2-sentiment-analysis-finetuning-wrime.ipynb
@@ -186,7 +186,7 @@
         }
       ],
       "source": [
-        "!pip install transformers[ja,torch] 'datasets<4.0.0' matplotlib japanize-matplotlib"
+        "!pip install 'transformers[ja,torch]<4.41.0'  'datasets<4.0.0' matplotlib japanize-matplotlib"
       ]
     },
     {

--- a/chapter05/5-2-sentiment-analysis-finetuning.ipynb
+++ b/chapter05/5-2-sentiment-analysis-finetuning.ipynb
@@ -196,7 +196,7 @@
         }
       ],
       "source": [
-        "!pip install transformers[ja,torch] 'datasets<4.0.0' matplotlib japanize-matplotlib"
+        "!pip install 'transformers[ja,torch]<4.41.0'  'datasets<4.0.0' matplotlib japanize-matplotlib"
       ]
     },
     {

--- a/chapter05/5-3-sentiment-analysis-analysis-wrime.ipynb
+++ b/chapter05/5-3-sentiment-analysis-analysis-wrime.ipynb
@@ -173,7 +173,7 @@
         }
       ],
       "source": [
-        "!pip install 'datasets<4.0.0' transformers[ja,torch] matplotlib scikit-learn"
+        "!pip install 'datasets<4.0.0' 'transformers[ja,torch]<4.41.0'  matplotlib scikit-learn"
       ]
     },
     {

--- a/chapter05/5-3-sentiment-analysis-analysis.ipynb
+++ b/chapter05/5-3-sentiment-analysis-analysis.ipynb
@@ -183,7 +183,7 @@
         }
       ],
       "source": [
-        "!pip install 'datasets<4.0.0' transformers[ja,torch] matplotlib scikit-learn"
+        "!pip install 'datasets<4.0.0' 'transformers[ja,torch]<4.41.0'  matplotlib scikit-learn"
       ]
     },
     {

--- a/chapter05/5-4-multiple-choice-qa-analysis.ipynb
+++ b/chapter05/5-4-multiple-choice-qa-analysis.ipynb
@@ -180,7 +180,7 @@
         }
       ],
       "source": [
-        "!pip install 'datasets<4.0.0' transformers[ja,torch] matplotlib scikit-learn"
+        "!pip install 'datasets<4.0.0' 'transformers[ja,torch]<4.41.0'  matplotlib scikit-learn"
       ]
     },
     {

--- a/chapter05/5-4-multiple-choice-qa-finetuning.ipynb
+++ b/chapter05/5-4-multiple-choice-qa-finetuning.ipynb
@@ -193,7 +193,7 @@
         }
       ],
       "source": [
-        "!pip install transformers[ja,torch] 'datasets<4.0.0' matplotlib japanize-matplotlib"
+        "!pip install 'transformers[ja,torch]<4.41.0'  'datasets<4.0.0' matplotlib japanize-matplotlib"
       ]
     },
     {

--- a/chapter05/5-4-nli-analysis.ipynb
+++ b/chapter05/5-4-nli-analysis.ipynb
@@ -180,7 +180,7 @@
         }
       ],
       "source": [
-        "!pip install 'datasets<4.0.0' transformers[ja,torch] matplotlib scikit-learn"
+        "!pip install 'datasets<4.0.0' 'transformers[ja,torch]<4.41.0'  matplotlib scikit-learn"
       ]
     },
     {

--- a/chapter05/5-4-nli-finetuning.ipynb
+++ b/chapter05/5-4-nli-finetuning.ipynb
@@ -193,7 +193,7 @@
         }
       ],
       "source": [
-        "!pip install transformers[ja,torch] 'datasets<4.0.0' matplotlib japanize-matplotlib"
+        "!pip install 'transformers[ja,torch]<4.41.0'  'datasets<4.0.0' matplotlib japanize-matplotlib"
       ]
     },
     {

--- a/chapter05/5-4-sts-analysis.ipynb
+++ b/chapter05/5-4-sts-analysis.ipynb
@@ -183,7 +183,7 @@
         }
       ],
       "source": [
-        "!pip install 'datasets<4.0.0' transformers[ja,torch] matplotlib japanize-matplotlib"
+        "!pip install 'datasets<4.0.0' 'transformers[ja,torch]<4.41.0'  matplotlib japanize-matplotlib"
       ]
     },
     {

--- a/chapter05/5-4-sts-finetuning.ipynb
+++ b/chapter05/5-4-sts-finetuning.ipynb
@@ -193,7 +193,7 @@
         }
       ],
       "source": [
-        "!pip install transformers[ja,torch] 'datasets<4.0.0' matplotlib japanize-matplotlib"
+        "!pip install 'transformers[ja,torch]<4.41.0'  'datasets<4.0.0' matplotlib japanize-matplotlib"
       ]
     },
     {

--- a/chapter05/5-5-sentiment-analysis-finetuning-LoRA-wrime.ipynb
+++ b/chapter05/5-5-sentiment-analysis-finetuning-LoRA-wrime.ipynb
@@ -199,7 +199,7 @@
         }
       ],
       "source": [
-        "!pip install transformers[ja,torch] 'datasets<4.0.0' matplotlib japanize-matplotlib peft"
+        "!pip install 'transformers[ja,torch]<4.41.0'  'datasets<4.0.0' matplotlib japanize-matplotlib peft"
       ]
     },
     {

--- a/chapter05/5-5-sentiment-analysis-finetuning-LoRA.ipynb
+++ b/chapter05/5-5-sentiment-analysis-finetuning-LoRA.ipynb
@@ -199,7 +199,7 @@
         }
       ],
       "source": [
-        "!pip install transformers[ja,torch] 'datasets<4.0.0' matplotlib japanize-matplotlib peft"
+        "!pip install 'transformers[ja,torch]<4.41.0'  'datasets<4.0.0' matplotlib japanize-matplotlib peft"
       ]
     },
     {

--- a/chapter06/6-named-entity-recognition.ipynb
+++ b/chapter06/6-named-entity-recognition.ipynb
@@ -169,7 +169,7 @@
         }
       ],
       "source": [
-        "!pip install 'datasets<4.0.0' transformers[ja,torch] spacy-alignments seqeval"
+        "!pip install 'datasets<4.0.0' 'transformers[ja,torch]<4.41.0'  spacy-alignments seqeval"
       ]
     },
     {

--- a/chapter07/7-summarization-generation.ipynb
+++ b/chapter07/7-summarization-generation.ipynb
@@ -173,7 +173,7 @@
         }
       ],
       "source": [
-        "!pip install 'datasets<4.0.0' transformers[ja,torch] sentencepiece japanize-matplotlib"
+        "!pip install 'datasets<4.0.0' 'transformers[ja,torch]<4.41.0'  sentencepiece japanize-matplotlib"
       ]
     },
     {

--- a/chapter08/8-3-simcse-training.ipynb
+++ b/chapter08/8-3-simcse-training.ipynb
@@ -8738,7 +8738,7 @@
       ],
       "source": [
         "# 必要なパッケージをインストールする\n",
-        "!pip install 'datasets<4.0.0' scipy transformers[ja,torch]"
+        "!pip install 'datasets<4.0.0' scipy 'transformers[ja,torch]<4.41.0' "
       ]
     },
     {

--- a/chapter08/8-4-simcse-faiss.ipynb
+++ b/chapter08/8-4-simcse-faiss.ipynb
@@ -4506,7 +4506,7 @@
     {
       "cell_type": "code",
       "source": [
-        "!pip install 'datasets<4.0.0' faiss-cpu scipy transformers[ja,torch]"
+        "!pip install 'datasets<4.0.0' faiss-cpu scipy 'transformers[ja,torch]<4.41.0' "
       ],
       "metadata": {
         "colab": {

--- a/chapter09/9-4-3-bpr-training.ipynb
+++ b/chapter09/9-4-3-bpr-training.ipynb
@@ -165,7 +165,7 @@
         }
       ],
       "source": [
-        "!pip install 'datasets<4.0.0' torch transformers[ja,torch]"
+        "!pip install 'datasets<4.0.0' torch 'transformers[ja,torch]<4.41.0' "
       ]
     },
     {

--- a/chapter09/9-4-4-bpr-embedding.ipynb
+++ b/chapter09/9-4-4-bpr-embedding.ipynb
@@ -2112,7 +2112,7 @@
     {
       "cell_type": "code",
       "source": [
-        "!pip install 'datasets<4.0.0' faiss-cpu torch transformers[ja,torch]"
+        "!pip install 'datasets<4.0.0' faiss-cpu torch 'transformers[ja,torch]<4.41.0' "
       ],
       "metadata": {
         "colab": {

--- a/chapter09/9-5-quiz-chatgpt-plus-bpr.ipynb
+++ b/chapter09/9-5-quiz-chatgpt-plus-bpr.ipynb
@@ -165,7 +165,7 @@
         }
       ],
       "source": [
-        "!pip install 'datasets<4.0.0' openai==0.27 tiktoken transformers[ja] faiss-cpu"
+        "!pip install 'datasets<4.0.0' openai==0.27 tiktoken 'transformers[ja]<4.41.0'  faiss-cpu"
       ]
     },
     {

--- a/chapter11/11-2-instruction_tuning-train.ipynb
+++ b/chapter11/11-2-instruction_tuning-train.ipynb
@@ -139,7 +139,7 @@
         }
       ],
       "source": [
-        "!pip install datasets transformers[torch,sentencepiece] trl peft bitsandbytes"
+        "!pip install datasets 'transformers[torch,sentencepiece]<4.41.0'  trl peft bitsandbytes"
       ]
     },
     {

--- a/chapter12/12-2-dpo-training.ipynb
+++ b/chapter12/12-2-dpo-training.ipynb
@@ -9471,7 +9471,7 @@
     {
       "cell_type": "code",
       "source": [
-        "!pip install datasets transformers[torch,sentencepiece] trl peft bitsandbytes"
+        "!pip install datasets 'transformers[torch,sentencepiece]<4.41.0'  trl peft bitsandbytes"
       ],
       "metadata": {
         "colab": {

--- a/chapter13/13-1-rag-overview.ipynb
+++ b/chapter13/13-1-rag-overview.ipynb
@@ -4161,7 +4161,7 @@
     {
       "cell_type": "code",
       "source": [
-        "!pip install transformers[torch,sentencepiece]"
+        "!pip install 'transformers[torch,sentencepiece]<4.41.0'"
       ],
       "metadata": {
         "colab": {

--- a/chapter13/13-2-rag-langchain.ipynb
+++ b/chapter13/13-2-rag-langchain.ipynb
@@ -8887,7 +8887,7 @@
     {
       "cell_type": "code",
       "source": [
-        "!pip install transformers[torch,sentencepiece] langchain langchain-community langchain-huggingface faiss-cpu jq"
+        "!pip install 'transformers[torch,sentencepiece]<4.41.0' langchain langchain-community langchain-huggingface faiss-cpu jq"
       ],
       "metadata": {
         "colab": {

--- a/chapter13/13-3-1-rag-instruct.ipynb
+++ b/chapter13/13-3-1-rag-instruct.ipynb
@@ -11446,7 +11446,7 @@
         }
       ],
       "source": [
-        "!pip install 'datasets<4.0.0' transformers[torch,sentencepiece] trl peft bitsandbytes"
+        "!pip install 'datasets<4.0.0' 'transformers[torch,sentencepiece]<4.41.0'  trl peft bitsandbytes"
       ]
     },
     {

--- a/chapter13/13-3-2-rag-instruct-langchain.ipynb
+++ b/chapter13/13-3-2-rag-instruct-langchain.ipynb
@@ -8892,7 +8892,7 @@
     {
       "cell_type": "code",
       "source": [
-        "!pip install transformers[torch,sentencepiece] langchain langchain-community langchain-huggingface faiss-cpu jq"
+        "!pip install 'transformers[torch,sentencepiece]<4.41.0' langchain langchain-community langchain-huggingface faiss-cpu jq"
       ],
       "metadata": {
         "colab": {


### PR DESCRIPTION
- https://github.com/ghmagazine/llm-book/issues/56

第5章以降の訓練コードを含むノートブック（および同じ章のノートブック）についてタイトル通りの変更を適用します。

transformers の [v4.41.0](https://github.com/huggingface/transformers/releases/tag/v4.41.0) で導入された変更 ([PR](https://github.com/huggingface/transformers/pull/30190)) により `TrainingArguments` の引数名が `evaluation_strategy` から `eval_strategy` に変わりました。
書籍との記述の一貫性を優先して、バージョン v4.41.0 で固定する形でノートブックを更新します。

第１章〜第３章のノートブックは訓練コードは含まず、モデルを読み込んで推論するしたり、トークナイザを使用するだけなので、transformers のバージョン固定は行いません。